### PR TITLE
Make command prompt behaviour user aware

### DIFF
--- a/java/server/src/org/openqa/grid/internal/utils/configuration/GridNodeConfiguration.java
+++ b/java/server/src/org/openqa/grid/internal/utils/configuration/GridNodeConfiguration.java
@@ -394,8 +394,8 @@ public class GridNodeConfiguration extends GridConfiguration {
     if (isMergeAble(other.downPollingLimit, downPollingLimit)) {
       downPollingLimit = other.downPollingLimit;
     }
-    if (isMergeAble(other.hub, hub)) {
-      hub = other.hub;
+    if (isMergeAble(other.hubOption, hubOption)) {
+      hubOption = other.hubOption;
     }
     if (isMergeAble(other.hubHost, hubHost)) {
       hubHost = other.hubHost;


### PR DESCRIPTION
[**With this commit**](https://github.com/ITmasc/selenium/commit/05a5bb9e2dd603a0ee3ad05a94cc6063ff9c843b) user can now choice wheter the debug command prompt can or not show it up when driver is loaded. This happens when python script are compiled into one-file exe.
With the above commit merged, the user can easily disable the cmd prompt in this way:
```
chrome_serv = Service("path-to-your-driver.exe")
chrome_serv.service_args = ["hide_console", ]
driver = webdriver.Chrome(service_args=chrome_serv.service_args, ...)
```
